### PR TITLE
JDCP-20: Expose NO_END_SEQNO for users

### DIFF
--- a/src/main/java/com/couchbase/client/dcp/state/SessionState.java
+++ b/src/main/java/com/couchbase/client/dcp/state/SessionState.java
@@ -45,7 +45,7 @@ public class SessionState {
     /**
      * Special Sequence number defined by DCP which says "no end".
      */
-    private static final long NO_END_SEQNO = 0xffffffffffffffffL;
+    public static final long NO_END_SEQNO = 0xffffffffffffffffL;
 
     /**
      * The current version format used on export, respected on import to aid backwards compatibility.


### PR DESCRIPTION
Kafka connector pulled previous int version of the constant and
introduced the same bug as described in JDCP-19
