### PR TITLE
JDCP-26: Open constructor of PartitionState

### DIFF
--- a/src/main/java/com/couchbase/client/dcp/state/PartitionState.java
+++ b/src/main/java/com/couchbase/client/dcp/state/PartitionState.java
@@ -64,7 +64,7 @@ public class PartitionState {
     /**
      * Initialize a new partition state.
      */
-    PartitionState() {
+    public PartitionState() {
         failoverLog = new CopyOnWriteArrayList<FailoverLogEntry>();
     }
 


### PR DESCRIPTION
## Motivation

In order to initialize Session programmatically, connector should be
able to create PartitionState objects.
## Result

Kafka connector can remove its workaround with
SessionState.setToBeginningWithNoEnd()
