### PR TITLE
Add Flush Message

### DIFF
--- a/src/main/java/com/couchbase/client/dcp/message/DcpFlushMessage.java
+++ b/src/main/java/com/couchbase/client/dcp/message/DcpFlushMessage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.dcp.message;
+
+import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
+
+public enum DcpFlushMessage {
+    ;
+    public static boolean is(final ByteBuf buffer) {
+        return buffer.getByte(0) == MessageUtil.MAGIC_REQ && buffer.getByte(1) == MessageUtil.DCP_FLUSH_OPCODE;
+    }
+}

--- a/src/main/java/com/couchbase/client/dcp/message/MessageUtil.java
+++ b/src/main/java/com/couchbase/client/dcp/message/MessageUtil.java
@@ -39,6 +39,7 @@ public enum MessageUtil {
     public static final byte SASL_AUTH_OPCODE = 0x21;
     public static final byte SASL_STEP_OPCODE = 0x22;
     public static final byte DCP_CONTROL_OPCODE = 0x5e;
+    public static final byte DCP_FLUSH_OPCODE = 0x5a;
     public static final byte DCP_STREAM_CLOSE_OPCODE = 0x52;
     public static final byte DCP_STREAM_REQUEST_OPCODE = 0x53;
     public static final byte DCP_FAILOVER_LOG_OPCODE = 0x54;
@@ -46,7 +47,7 @@ public enum MessageUtil {
     public static final byte DCP_SNAPSHOT_MARKER_OPCODE = 0x56;
     public static final byte DCP_MUTATION_OPCODE = 0x57;
     public static final byte DCP_DELETION_OPCODE = 0x58;
-    public static final byte DCP_EXPIRATION_OPCODE = 0x58;
+    public static final byte DCP_EXPIRATION_OPCODE = 0x59;
     public static final byte DCP_NOOP_OPCODE = 0x5C;
     public static final byte DCP_BUFFER_ACK_OPCODE = 0x5D;
 

--- a/src/main/java/com/couchbase/client/dcp/transport/netty/DcpMessageHandler.java
+++ b/src/main/java/com/couchbase/client/dcp/transport/netty/DcpMessageHandler.java
@@ -18,9 +18,23 @@ package com.couchbase.client.dcp.transport.netty;
 import com.couchbase.client.core.logging.CouchbaseLogger;
 import com.couchbase.client.core.logging.CouchbaseLoggerFactory;
 import com.couchbase.client.dcp.DataEventHandler;
-import com.couchbase.client.dcp.message.*;
+import com.couchbase.client.dcp.message.DcpCloseStreamResponse;
+import com.couchbase.client.dcp.message.DcpDeletionMessage;
+import com.couchbase.client.dcp.message.DcpExpirationMessage;
+import com.couchbase.client.dcp.message.DcpFailoverLogResponse;
+import com.couchbase.client.dcp.message.DcpFlushMessage;
+import com.couchbase.client.dcp.message.DcpGetPartitionSeqnosResponse;
+import com.couchbase.client.dcp.message.DcpMutationMessage;
+import com.couchbase.client.dcp.message.DcpNoopRequest;
+import com.couchbase.client.dcp.message.DcpNoopResponse;
+import com.couchbase.client.dcp.message.DcpOpenStreamResponse;
+import com.couchbase.client.dcp.message.DcpSnapshotMarkerMessage;
+import com.couchbase.client.dcp.message.DcpStreamEndMessage;
+import com.couchbase.client.dcp.message.MessageUtil;
 import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
-import com.couchbase.client.deps.io.netty.channel.*;
+import com.couchbase.client.deps.io.netty.channel.ChannelDuplexHandler;
+import com.couchbase.client.deps.io.netty.channel.ChannelHandlerContext;
+
 import rx.subjects.Subject;
 
 /**
@@ -90,7 +104,8 @@ public class DcpMessageHandler extends ChannelDuplexHandler {
             || DcpSnapshotMarkerMessage.is(msg)
             || DcpFailoverLogResponse.is(msg)
             || DcpCloseStreamResponse.is(msg)
-            || DcpGetPartitionSeqnosResponse.is(msg);
+            || DcpGetPartitionSeqnosResponse.is(msg)
+            || DcpFlushMessage.is(msg);
     }
 
     /**


### PR DESCRIPTION
This change adds the flush message which can be used when the bucket has been flushed. In addition, it fixes the not yet used expiration op code.