### PR TITLE
JDCP-31: introduce mechanism to deliver internal notifications

### DIFF
--- a/src/main/java/com/couchbase/client/dcp/Client.java
+++ b/src/main/java/com/couchbase/client/dcp/Client.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.couchbase.client.core.event.EventBus;
 import com.couchbase.client.core.logging.CouchbaseLogger;
 import com.couchbase.client.core.logging.CouchbaseLoggerFactory;
 import com.couchbase.client.core.time.Delay;
@@ -105,6 +106,7 @@ public class Client {
             .setConfigProviderReconnectMaxAttempts(builder.configProviderReconnectMaxAttempts)
             .setDcpChannelsReconnectDelay(builder.dcpChannelsReconnectDelay)
             .setDcpChannelsReconnectMaxAttempts(builder.dcpChannelsReconnectMaxAttempts)
+            .setEventBus(builder.eventBus)
             .build();
 
         bufferAckEnabled = env.dcpControl().bufferAckEnabled();
@@ -212,6 +214,13 @@ public class Client {
                 controlEventHandler.onEvent(event);
             }
         });
+    }
+
+    /**
+     * Stores a {@link SystemEventHandler} to be called when control events happen.
+     */
+    public void systemEventHandler(final SystemEventHandler systemEventHandler) {
+        env.setSystemEventHandler(systemEventHandler);
     }
 
     /**
@@ -743,6 +752,7 @@ public class Client {
         private int configProviderReconnectMaxAttempts = ClientEnvironment.DEFAULT_CONFIG_PROVIDER_RECONNECT_MAX_ATTEMPTS;
         private int dcpChannelsReconnectMaxAttempts = ClientEnvironment.DEFAULT_DCP_CHANNELS_RECONNECT_MAX_ATTEMPTS;
         private Delay dcpChannelsReconnectDelay = ClientEnvironment.DEFAULT_DCP_CHANNELS_RECONNECT_DELAY;
+        private EventBus eventBus;
 
         /**
          * The buffer acknowledge watermark in percent.
@@ -921,6 +931,16 @@ public class Client {
          */
         public Builder dcpChannelsReconnectDelay(Delay dcpChannelsReconnectDelay){
             this.dcpChannelsReconnectDelay = dcpChannelsReconnectDelay;
+            return this;
+        }
+
+        /**
+         * Sets the event bus to an alternative implementation.
+         *
+         * This setting should only be tweaked in advanced cases.
+         */
+        public Builder eventBus(final EventBus eventBus) {
+            this.eventBus = eventBus;
             return this;
         }
 

--- a/src/main/java/com/couchbase/client/dcp/SystemEventHandler.java
+++ b/src/main/java/com/couchbase/client/dcp/SystemEventHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.dcp;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+
+/**
+ * This interface acts as a callback on the {@link Client#systemEventHandler(SystemEventHandler)} API
+ * that allows one to react to system events.
+ */
+public interface SystemEventHandler {
+
+    /**
+     * Called every time when a system event happens that should be handled by
+     * consumers of the {@link Client}.
+     *
+     * @param event the system event happening.
+     */
+    void onEvent(CouchbaseEvent event);
+}

--- a/src/main/java/com/couchbase/client/dcp/events/FailedToAddNodeEvent.java
+++ b/src/main/java/com/couchbase/client/dcp/events/FailedToAddNodeEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.dcp.events;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+import com.couchbase.client.core.event.EventType;
+import com.couchbase.client.core.utils.Events;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+/**
+ * Event published when the connector has failed to add new node during failover/rebalance.
+ */
+public class FailedToAddNodeEvent implements CouchbaseEvent {
+    private final InetAddress node;
+    private final Throwable error;
+
+    public FailedToAddNodeEvent(InetAddress node, Throwable error) {
+        this.node = node;
+        this.error = error;
+    }
+
+    @Override
+    public EventType type() {
+        return EventType.SYSTEM;
+    }
+
+    /**
+     * The address of the node
+     */
+    public InetAddress node() {
+        return node;
+    }
+
+    /**
+     * Error object, describing the issue
+     */
+    public Throwable error() {
+        return error;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = Events.identityMap(this);
+        result.put("node", node);
+        result.put("error", error);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FailedToAddNodeEvent{" +
+                "node=" + node +
+                "error=" + error +
+                '}';
+    }
+}

--- a/src/main/java/com/couchbase/client/dcp/events/FailedToMovePartitionEvent.java
+++ b/src/main/java/com/couchbase/client/dcp/events/FailedToMovePartitionEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.dcp.events;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+import com.couchbase.client.core.event.EventType;
+import com.couchbase.client.core.utils.Events;
+
+import java.util.Map;
+
+/**
+ * Event published when the connector has failed to move partition to new node during failover/rebalance.
+ */
+public class FailedToMovePartitionEvent implements CouchbaseEvent {
+
+    private final short partition;
+    private final Throwable error;
+
+    public FailedToMovePartitionEvent(short partition, Throwable error) {
+        this.partition = partition;
+        this.error = error;
+    }
+
+    @Override
+    public EventType type() {
+        return EventType.SYSTEM;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = Events.identityMap(this);
+        result.put("partition", partition);
+        result.put("error", error);
+        return result;
+    }
+
+    /**
+     * The partition ID which has caused issue
+     */
+    public short partition() {
+        return partition;
+    }
+
+    /**
+     * Error object, describing the issue
+     */
+    public Throwable error() {
+        return error;
+    }
+
+    @Override
+    public String toString() {
+        return "FailedToMovePartitionEvent{" +
+                "partition=" + partition +
+                "error=" + error +
+                '}';
+    }
+}

--- a/src/main/java/com/couchbase/client/dcp/events/FailedToRemoveNodeEvent.java
+++ b/src/main/java/com/couchbase/client/dcp/events/FailedToRemoveNodeEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.dcp.events;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+import com.couchbase.client.core.event.EventType;
+import com.couchbase.client.core.utils.Events;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+/**
+ * Event published when the connector has failed to remove node during failover/rebalance.
+ */
+public class FailedToRemoveNodeEvent implements CouchbaseEvent {
+    private final InetAddress node;
+    private final Throwable error;
+
+    public FailedToRemoveNodeEvent(InetAddress node, Throwable error) {
+        this.node = node;
+        this.error = error;
+    }
+
+    @Override
+    public EventType type() {
+        return EventType.SYSTEM;
+    }
+
+    /**
+     * The address of the node
+     */
+    public InetAddress node() {
+        return node;
+    }
+
+    /**
+     * Error object, describing the issue
+     */
+    public Throwable error() {
+        return error;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = Events.identityMap(this);
+        result.put("node", node);
+        result.put("error", error);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FailedToRemoveNodeEvent{" +
+                "node=" + node +
+                "error=" + error +
+                '}';
+    }
+}

--- a/src/main/java/com/couchbase/client/dcp/events/StreamEndEvent.java
+++ b/src/main/java/com/couchbase/client/dcp/events/StreamEndEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.dcp.events;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+import com.couchbase.client.core.event.EventType;
+import com.couchbase.client.core.utils.Events;
+import com.couchbase.client.dcp.message.StreamEndReason;
+
+import java.util.Map;
+
+/**
+ * Event published when stream has stopped activity.
+ */
+public class StreamEndEvent implements CouchbaseEvent {
+    private final short partition;
+    private final StreamEndReason reason;
+
+    public StreamEndEvent(short partition, StreamEndReason reason) {
+        this.partition = partition;
+        this.reason = reason;
+    }
+
+    @Override
+    public EventType type() {
+        return EventType.SYSTEM;
+    }
+
+    public short partition() {
+        return partition;
+    }
+
+    public StreamEndReason reason() {
+        return reason;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = Events.identityMap(this);
+        result.put("partition", partition);
+        result.put("reason", reason);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "StreamEndEvent{" +
+                "partition=" + partition +
+                "reason=" + reason +
+                '}';
+    }
+}

--- a/src/test/java/examples/AirportsInFrance.java
+++ b/src/test/java/examples/AirportsInFrance.java
@@ -15,11 +15,14 @@
  */
 package examples;
 
+import com.couchbase.client.core.event.CouchbaseEvent;
 import com.couchbase.client.dcp.Client;
 import com.couchbase.client.dcp.ControlEventHandler;
 import com.couchbase.client.dcp.DataEventHandler;
 import com.couchbase.client.dcp.StreamFrom;
 import com.couchbase.client.dcp.StreamTo;
+import com.couchbase.client.dcp.SystemEventHandler;
+import com.couchbase.client.dcp.events.StreamEndEvent;
 import com.couchbase.client.dcp.message.DcpMutationMessage;
 import com.couchbase.client.dcp.message.DcpSnapshotMarkerRequest;
 import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
@@ -72,6 +75,17 @@ public class AirportsInFrance {
                     }
                 }
                 event.release();
+            }
+        });
+        client.systemEventHandler(new SystemEventHandler() {
+            @Override
+            public void onEvent(CouchbaseEvent event) {
+                if (event instanceof StreamEndEvent) {
+                    StreamEndEvent streamEnd = (StreamEndEvent) event;
+                    if (streamEnd.partition() == 42) {
+                        System.out.println("Stream for partition 42 has ended (reason: " + streamEnd.reason() + ")");
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
At the moment connector broadcasts the following events:

* End of stream
* Partition move failure
* Adding node failure
* Removing node failure