### PR TITLE
Add benchmark for streaming from Couchbase server.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <java-compat.version>1.6</java-compat.version>
         <core.version>1.4.5</core.version>
         <client.version>2.4.4</client.version>
+        <jmh.version>1.19</jmh.version>
     </properties>
 
     <name>Couchbase Java DCP Client</name>
@@ -94,6 +95,13 @@
             <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
+        <!-- Benchmark -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- for examples -->
         <dependency>
             <groupId>commons-io</groupId>
@@ -118,11 +126,28 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5.1</version>
                 <configuration>
                     <source>${java-compat.version}</source>
                     <target>${java-compat.version}</target>
                 </configuration>
+                <executions>
+                    <!-- Apply JMH annotation processor when compiling performance tests-->
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.openjdk.jmh</groupId>
+                                    <artifactId>jmh-generator-annprocess</artifactId>
+                                    <version>${jmh.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -139,6 +164,7 @@
                             <sources>
                                 <!-- add the following sources in addition to the unit tests -->
                                 <source>${test-source-directory}</source>
+                                <source>src/perf/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -193,6 +219,31 @@
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
+            </plugin>
+            <!-- Performance tests assembly -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <descriptor>src/main/assembly/perf-tests.xml</descriptor>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <attach>true</attach>
+                            <archive>
+                                <manifest>
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/assembly/perf-tests.xml
+++ b/src/main/assembly/perf-tests.xml
@@ -1,0 +1,28 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>perf-tests</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>${file.separator}</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/perf/java/com/couchbase/client/dcp/benchmark/BenchmarkHelper.java
+++ b/src/perf/java/com/couchbase/client/dcp/benchmark/BenchmarkHelper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.dcp.benchmark;
+
+import java.util.concurrent.CountDownLatch;
+
+import com.couchbase.client.core.event.CouchbaseEvent;
+import com.couchbase.client.dcp.Client;
+import com.couchbase.client.dcp.ControlEventHandler;
+import com.couchbase.client.dcp.DataEventHandler;
+import com.couchbase.client.dcp.StreamFrom;
+import com.couchbase.client.dcp.StreamTo;
+import com.couchbase.client.dcp.SystemEventHandler;
+import com.couchbase.client.dcp.events.StreamEndEvent;
+import com.couchbase.client.dcp.message.DcpSnapshotMarkerRequest;
+import com.couchbase.client.dcp.transport.netty.ChannelFlowController;
+import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Utility methods common to the different benchmarks.
+ */
+class BenchmarkHelper {
+    private BenchmarkHelper() {
+    }
+
+    /**
+     * Returns a connected client configured to read all data and control events and send the
+     * results to given black hole.
+     */
+    static Client createConnectedClient(final Blackhole blackhole) {
+        Client client = Client.configure()
+                .hostnames("localhost")
+                .bucket("travel-sample")
+                .build();
+
+        // Don't do anything with control events in this example
+        client.controlEventHandler(new ControlEventHandler() {
+            @Override
+            public void onEvent(ChannelFlowController flowController, ByteBuf event) {
+                if (DcpSnapshotMarkerRequest.is(event)) {
+                    flowController.ack(event);
+                }
+                readAndConsume(event, blackhole);
+                event.release();
+            }
+        });
+
+        client.dataEventHandler(new DataEventHandler() {
+            @Override
+            public void onEvent(ChannelFlowController flowController, ByteBuf event) {
+                readAndConsume(event, blackhole);
+                event.release();
+            }
+        });
+
+        // Connect the sockets
+        client.connect().await();
+
+        return client;
+    }
+
+    /**
+     * Copies the contents of the buffer to a byte array and sends that array to the black hole.
+     */
+    private static void readAndConsume(ByteBuf buffer, Blackhole blackhole) {
+        byte[] bytes = new byte[buffer.readableBytes()];
+        buffer.getBytes(0, bytes);
+        blackhole.consume(bytes);
+    }
+
+    /**
+     * Streams from beginning to now. Waits for all partitions to finish streaming.
+     *
+     * @param client a connected client
+     */
+    static void streamAndAwaitCompletion(Client client) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(client.numPartitions());
+
+        client.systemEventHandler(new SystemEventHandler() {
+            @Override
+            public void onEvent(CouchbaseEvent event) {
+                if (event instanceof StreamEndEvent) {
+                    latch.countDown();
+                }
+            }
+        });
+
+        client.initializeState(StreamFrom.BEGINNING, StreamTo.NOW).await();
+        client.startStreaming().await();
+
+        // Wait until all partition streams have ended
+        latch.await();
+    }
+}

--- a/src/perf/java/com/couchbase/client/dcp/benchmark/ConnectAndStreamBenchmark.java
+++ b/src/perf/java/com/couchbase/client/dcp/benchmark/ConnectAndStreamBenchmark.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.dcp.benchmark;
+
+import com.couchbase.client.dcp.Client;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class ConnectAndStreamBenchmark {
+
+    /**
+     * Connects to a Couchbase server and stream the DCP updates for the "travel-sample" bucket.
+     */
+    @Benchmark
+    public void testMethod(Blackhole blackhole) throws Exception {
+        Client client = BenchmarkHelper.createConnectedClient(blackhole);
+
+        BenchmarkHelper.streamAndAwaitCompletion(client);
+
+        client.disconnect().await();
+    }
+}
+
+

--- a/src/perf/java/com/couchbase/client/dcp/benchmark/StreamBenchmark.java
+++ b/src/perf/java/com/couchbase/client/dcp/benchmark/StreamBenchmark.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.dcp.benchmark;
+
+import com.couchbase.client.dcp.Client;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class StreamBenchmark {
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        private Client client;
+
+        @Setup(Level.Trial)
+        public void connect(Blackhole blackhole) {
+            client = BenchmarkHelper.createConnectedClient(blackhole);
+        }
+
+        @TearDown(Level.Trial)
+        public void disconnect() {
+            client.disconnect().await();
+        }
+    }
+
+    /**
+     * Streams the DCP updates for the "travel-sample" bucket.
+     */
+    @Benchmark
+    public void testMethod(BenchmarkState benchmarkState) throws Exception {
+        BenchmarkHelper.streamAndAwaitCompletion(benchmarkState.client);
+    }
+}
+
+

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
POM changes are based on https://stackoverflow.com/a/39374972

The added benchmarks require a server running on localhost, populated with "travel-sample" data.

To run the benchmarks:

    $ mvn clean package -DskipTests
    $ java -jar target/dcp-client-<VERSION>-perf-tests.jar
           (add -h to see list of JMH command line options)

The "ConnectAndStream" benchmark measures the time it takes to connect to the Couchbase server, stream all the data from the "travel-sample" bucket, and disconnect.

The "StreamBenchmark" is a work in progress. It attempts to improve on "ConnectAndStream" by
reusing the same Client for each invocation in order to exclude the time it takes to connect to the server. It's currently broken though; perhaps it's missing some important step to reset the client properly between streaming sessions.

Command to run just the working benchmark:

    $ java -jar target/dcp-client-<VERSION>-perf-tests.jar ConnectAndStream