### PR TITLE
Fixed UnsuportedOperationException bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.8.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- for examples -->
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/com/couchbase/client/dcp/state/SessionState.java
+++ b/src/main/java/com/couchbase/client/dcp/state/SessionState.java
@@ -22,7 +22,9 @@ import com.couchbase.client.deps.com.fasterxml.jackson.databind.annotation.JsonD
 import com.couchbase.client.deps.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import rx.functions.Action1;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -164,14 +166,18 @@ public class SessionState {
         ps.setStartSeqno(seqno);
         ps.setSnapshotStartSeqno(seqno);
         ps.setSnapshotEndSeqno(seqno);
-        Iterator<FailoverLogEntry> flog = ps.getFailoverLog().iterator();
-        while (flog.hasNext()) {
-            FailoverLogEntry entry = flog.next();
+        List<FailoverLogEntry> failoverLog = ps.getFailoverLog();
+        Iterator<FailoverLogEntry> flogIterator = failoverLog.iterator();
+        List<FailoverLogEntry> entriesToRemove = new ArrayList<FailoverLogEntry>();
+        while (flogIterator.hasNext()) {
+            FailoverLogEntry entry = flogIterator.next();
             // check if this entry is has a higher seqno than we need to roll back to
             if (entry.getSeqno() > seqno) {
-                flog.remove();
+                entriesToRemove.add(entry);
             }
         }
+        failoverLog.removeAll(entriesToRemove);
+
         partitionStates.set(partition, ps);
     }
 

--- a/src/test/java/com/couchbase/client/dcp/state/SessionStateTest.java
+++ b/src/test/java/com/couchbase/client/dcp/state/SessionStateTest.java
@@ -1,0 +1,34 @@
+package com.couchbase.client.dcp.state;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+
+
+public class SessionStateTest {
+    @Test
+    public void rollbackToPosition() throws Exception {
+        // Populate a session state with dummy data for a single partition
+        final SessionState sessionState = new SessionState();
+        PartitionState partitionState = new PartitionState();
+        partitionState.addToFailoverLog(5, 12345);
+        partitionState.setStartSeqno(1);
+        partitionState.setEndSeqno(1000);
+        partitionState.setSnapshotStartSeqno(2);
+        partitionState.setSnapshotEndSeqno(3);
+        sessionState.set(0, partitionState);
+
+        Throwable th = catchThrowable(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                sessionState.rollbackToPosition((short) 0, 1L);
+            }
+        });
+
+        assertThat(th).isNull();
+
+    }
+
+}


### PR DESCRIPTION
Hello guys.

I've just found a bug at your dcp client. Last version from your master is affected.
The problem is located here:
```
 /**
     * Helper method to rollback the given partition to the given sequence number.
     *
     * This will set the seqno AND REMOVE ALL ENTRIES from the failover log that are higher
     * than the given sequence number!
     *
     * @param partition the partition to rollback
     * @param seqno the sequence number where to roll it back to.
     */
    public void rollbackToPosition(short partition, long seqno) {
        PartitionState ps = partitionStates.get(partition);
        ps.setStartSeqno(seqno);
        ps.setSnapshotStartSeqno(seqno);
        ps.setSnapshotEndSeqno(seqno);
        Iterator<FailoverLogEntry> flog = ps.getFailoverLog().iterator();
        while (flog.hasNext()) {
            FailoverLogEntry entry = flog.next();
            // check if this entry is has a higher seqno than we need to roll back to
            if (entry.getSeqno() > seqno) {
                flog.remove();  // <- bug here
            }
        }
        partitionStates.set(partition, ps);
    }
```
In fact flog iterator does not support remove method as it actually is:
```
package java.util.concurrent;
...
public class CopyOnWriteArrayList<E> {
...
 static final class COWIterator<E> implements ListIterator<E> {
...
      /**
         * Not supported. Always throws UnsupportedOperationException.
         * @throws UnsupportedOperationException always; {@code remove}
         *         is not supported by this iterator.
         */
        public void remove() {
            throw new UnsupportedOperationException();
        }
...
 }
...
}
```
So I created an unit test and patch. Please review it and merge. 

